### PR TITLE
chore: update deps

### DIFF
--- a/apps/cms/src/app/next/seed/globals/route.ts
+++ b/apps/cms/src/app/next/seed/globals/route.ts
@@ -1,0 +1,27 @@
+import { getPayloadClient } from "@synoem/payload/client";
+import { headers } from "next/headers";
+
+export async function POST(): Promise<Response> {
+  const payload = await getPayloadClient();
+  const requestHeaders = await headers();
+
+  // Authenticate by passing request headers
+  const { user } = await payload.auth({ headers: requestHeaders });
+
+  if (!user) {
+    return new Response("Action forbidden.", { status: 403 });
+  }
+
+  try {
+    // Create a Payload request object to pass to the Local API for transactions
+    // At this point you should pass in a user, locale, and any other context you need for the Local API
+    //   const payloadReq = await createLocalReq({ user }, payload);
+
+    //   await resetDatabase(payload, payloadReq);
+
+    return Response.json({ success: true });
+  } catch (e) {
+    payload.logger.error({ err: e, message: "Error seeding data" });
+    return new Response("Error seeding data.", { status: 500 });
+  }
+}

--- a/apps/cms/src/app/next/seed/images/route.ts
+++ b/apps/cms/src/app/next/seed/images/route.ts
@@ -1,0 +1,408 @@
+import type { File } from "payload";
+import { getPayloadClient } from "@synoem/payload/client";
+import { headers } from "next/headers";
+
+export const maxDuration = 60;
+
+const IMAGE_BASE_URL = `${process.env.NEXT_PUBLIC_S3_ENDPOINT}/object/public/${process.env.NEXT_PUBLIC_S3_BUCKET_NAME}/images/seed`;
+const LOGO_BASE_URL = `${process.env.NEXT_PUBLIC_S3_ENDPOINT}/object/public/${process.env.NEXT_PUBLIC_S3_BUCKET_NAME}/icons`;
+
+function getMimeType(filename: string): string {
+  const ext = filename.split(".").pop()?.toLowerCase();
+  if (ext === "svg") return "image/svg+xml";
+  if (ext === "jpg" || ext === "jpeg") return "image/jpeg";
+  if (ext === "png") return "image/png";
+  if (ext === "webp") return "image/webp";
+  if (ext === "gif") return "image/gif";
+
+  throw new Error(`Unsupported file type: ${ext}`);
+}
+
+async function fetchFileByURL(url: string): Promise<File> {
+  if (!url.startsWith(IMAGE_BASE_URL) && !url.startsWith(LOGO_BASE_URL)) {
+    throw new Error(`Invalid URL: ${url}`);
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 60000);
+
+  try {
+    const res = await fetch(url, {
+      credentials: "include",
+      method: "GET",
+      signal: controller.signal,
+    });
+    clearTimeout(timeout);
+
+    if (!res.ok) {
+      throw new Error(`Failed to fetch file from ${url}, status: ${res.status}`);
+    }
+    const data = await res.arrayBuffer();
+    const name = url.split("/").pop() || `file-${Date.now()}`;
+
+    console.log("File fetched", name);
+
+    return {
+      name,
+      data: Buffer.from(data),
+      mimetype: getMimeType(name),
+      size: data.byteLength,
+    };
+  } catch (error) {
+    clearTimeout(timeout);
+    console.log("Fetching file from", url, "failed", error);
+    throw error;
+  }
+}
+
+export async function POST(): Promise<Response> {
+  const payload = await getPayloadClient();
+  const requestHeaders = await headers();
+
+  // Authenticate by passing request headers
+  const { user } = await payload.auth({ headers: requestHeaders });
+
+  if (!user) {
+    return new Response("Action forbidden.", { status: 403 });
+  }
+
+  try {
+    // Create a Payload request object to pass to the Local API for transactions
+    // At this point you should pass in a user, locale, and any other context you need for the Local API
+    // const payloadReq = await createLocalReq({ user }, payload);
+
+    const [
+      industryCoverImage,
+      hjtHeroImage,
+      topconHeroImage,
+      solarPanel1HeroImage,
+      solarPanel2HeroImage,
+      logo,
+      openGraphImage,
+      factoryImage,
+      solarPanel1ProductImage,
+      solarPanel2ProductImage,
+      solarPanel3ProductImage,
+      solarPanel4ProductImage,
+      // logos
+      ceLogo,
+      ulLogo,
+      mcsLogo,
+      // hero images
+      heroContent1,
+      heroContent2,
+      heroContent3,
+      heroContent4,
+      heroContent5,
+      heroContent6,
+    ] = await Promise.all([
+      fetchFileByURL(`${IMAGE_BASE_URL}/industry-cover-image.jpg`),
+      fetchFileByURL(`${IMAGE_BASE_URL}/hjt-hero.jpg`),
+      fetchFileByURL(`${IMAGE_BASE_URL}/topcon-hero.jpg`),
+      fetchFileByURL(`${IMAGE_BASE_URL}/solar-panel-1-hero.jpg`),
+      fetchFileByURL(`${IMAGE_BASE_URL}/solar-panel-2-hero.jpg`),
+      fetchFileByURL(`${IMAGE_BASE_URL}/logo-transparent.svg`),
+      fetchFileByURL(`${IMAGE_BASE_URL}/open-graph.png`),
+      fetchFileByURL(`${IMAGE_BASE_URL}/factory.jpg`),
+      // solar panel product images
+      fetchFileByURL(`${IMAGE_BASE_URL}/solar-panel_1.png`),
+      fetchFileByURL(`${IMAGE_BASE_URL}/solar-panel_2.png`),
+      fetchFileByURL(`${IMAGE_BASE_URL}/solar-panel_3.png`),
+      fetchFileByURL(`${IMAGE_BASE_URL}/solar-panel_4.png`),
+
+      // logos
+      fetchFileByURL(`${LOGO_BASE_URL}/ce.svg`),
+      fetchFileByURL(`${LOGO_BASE_URL}/ul.svg`),
+      fetchFileByURL(`${LOGO_BASE_URL}/mcs.svg`),
+
+      // Hero images
+      fetchFileByURL(`${IMAGE_BASE_URL}/hero-content-1.jpg`),
+      fetchFileByURL(`${IMAGE_BASE_URL}/hero-content-2.jpg`),
+      fetchFileByURL(`${IMAGE_BASE_URL}/hero-content-3.jpg`),
+      fetchFileByURL(`${IMAGE_BASE_URL}/hero-content-4.png`),
+      fetchFileByURL(`${IMAGE_BASE_URL}/hero-content-5.png`),
+      fetchFileByURL(`${IMAGE_BASE_URL}/hero-content-6.png`),
+    ]);
+
+    payload.logger.info("Images fetched");
+
+    // images
+    const [
+      createdIndustryCoverImage,
+      createdHjtHeroImage,
+      createdTopconHeroImage,
+      createdSolarPanel1HeroImage,
+      createdSolarPanel2HeroImage,
+      createdLogo,
+      createdOpenGraphImage,
+      createdFactoryImage,
+      createdSolarPanel1ProductImage,
+      createdSolarPanel2ProductImage,
+      createdSolarPanel3ProductImage,
+      createdSolarPanel4ProductImage,
+      createdCeLogo,
+      createdUlLogo,
+      createdMcsLogo,
+      createdHeroContent1,
+      createdHeroContent2,
+      createdHeroContent3,
+      createdHeroContent4,
+      createdHeroContent5,
+      createdHeroContent6,
+    ] = await Promise.all([
+      payload.create({
+        collection: "images",
+        data: {
+          alt: "Renewable Energy",
+        },
+        file: industryCoverImage,
+        context: {
+          skipRevalidation: true,
+        },
+      }),
+      payload.create({
+        collection: "images",
+        data: {
+          alt: "HJT Solar Panel",
+        },
+        file: hjtHeroImage,
+        context: {
+          skipRevalidation: true,
+        },
+      }),
+      payload.create({
+        collection: "images",
+        data: {
+          alt: "Topcon Solar Panel",
+        },
+        file: topconHeroImage,
+        context: {
+          skipRevalidation: true,
+        },
+      }),
+      payload.create({
+        collection: "images",
+        data: {
+          alt: "Solar Panel 1",
+        },
+        file: solarPanel1HeroImage,
+        context: {
+          skipRevalidation: true,
+        },
+      }),
+      payload.create({
+        collection: "images",
+        data: {
+          alt: "Solar Panel 2",
+        },
+        file: solarPanel2HeroImage,
+        context: {
+          skipRevalidation: true,
+        },
+      }),
+      payload.create({
+        collection: "images",
+        data: {
+          alt: "Logo",
+        },
+        file: logo,
+        context: {
+          skipRevalidation: true,
+        },
+      }),
+      payload.create({
+        collection: "images",
+        data: {
+          alt: "Open Graph Image",
+        },
+        file: openGraphImage,
+        context: {
+          skipRevalidation: true,
+        },
+      }),
+      payload.create({
+        collection: "images",
+        data: {
+          alt: "Factory",
+        },
+        file: factoryImage,
+        context: {
+          skipRevalidation: true,
+        },
+      }),
+
+      // solar panel product images
+      payload.create({
+        collection: "images",
+        data: {
+          alt: "Solar Panel 1 Product",
+        },
+        file: solarPanel1ProductImage,
+        context: {
+          skipRevalidation: true,
+        },
+      }),
+      payload.create({
+        collection: "images",
+        data: {
+          alt: "Solar Panel 2 Product",
+        },
+        file: solarPanel2ProductImage,
+        context: {
+          skipRevalidation: true,
+        },
+      }),
+      payload.create({
+        collection: "images",
+        data: {
+          alt: "Solar Panel 3 Product",
+        },
+        file: solarPanel3ProductImage,
+        context: {
+          skipRevalidation: true,
+        },
+      }),
+      payload.create({
+        collection: "images",
+        data: {
+          alt: "Solar Panel 4 Product",
+        },
+        file: solarPanel4ProductImage,
+        context: {
+          skipRevalidation: true,
+        },
+      }),
+
+      // logos
+      payload.create({
+        collection: "images",
+        data: {
+          alt: "CE Logo",
+        },
+        file: ceLogo,
+        context: {
+          skipRevalidation: true,
+        },
+      }),
+      payload.create({
+        collection: "images",
+        data: {
+          alt: "UL Logo",
+        },
+        file: ulLogo,
+        context: {
+          skipRevalidation: true,
+        },
+      }),
+      payload.create({
+        collection: "images",
+        data: {
+          alt: "MCS Logo",
+        },
+        file: mcsLogo,
+        context: {
+          skipRevalidation: true,
+        },
+      }),
+
+      // hero images
+      payload.create({
+        collection: "images",
+        data: {
+          alt: "Hero Content 1",
+        },
+        file: heroContent1,
+        context: {
+          skipRevalidation: true,
+        },
+      }),
+      payload.create({
+        collection: "images",
+        data: {
+          alt: "Hero Content 2",
+        },
+        file: heroContent2,
+        context: {
+          skipRevalidation: true,
+        },
+      }),
+      payload.create({
+        collection: "images",
+        data: {
+          alt: "Hero Content 3",
+        },
+        file: heroContent3,
+        context: {
+          skipRevalidation: true,
+        },
+      }),
+
+      payload.create({
+        collection: "images",
+        data: {
+          alt: "Hero Content 4",
+        },
+        file: heroContent4,
+        context: {
+          skipRevalidation: true,
+        },
+      }),
+
+      payload.create({
+        collection: "images",
+        data: {
+          alt: "Hero Content 5",
+        },
+        file: heroContent5,
+        context: {
+          skipRevalidation: true,
+        },
+      }),
+
+      payload.create({
+        collection: "images",
+        data: {
+          alt: "Hero Content 6",
+        },
+        file: heroContent6,
+        context: {
+          skipRevalidation: true,
+        },
+      }),
+    ]);
+
+    console.log("createdFactoryImage to be used", createdFactoryImage);
+
+    payload.logger.info("Images created");
+
+    return Response.json({
+      success: true,
+      images: {
+        createdIndustryCoverImage: createdIndustryCoverImage.id,
+        createdHjtHeroImage: createdHjtHeroImage.id,
+        createdTopconHeroImage: createdTopconHeroImage.id,
+        createdSolarPanel1HeroImage: createdSolarPanel1HeroImage.id,
+        createdSolarPanel2HeroImage: createdSolarPanel2HeroImage.id,
+        createdLogo: createdLogo.id,
+        createdOpenGraphImage: createdOpenGraphImage.id,
+        createdFactoryImage: createdFactoryImage.id,
+        createdSolarPanel1ProductImage: createdSolarPanel1ProductImage.id,
+        createdSolarPanel2ProductImage: createdSolarPanel2ProductImage.id,
+        createdSolarPanel3ProductImage: createdSolarPanel3ProductImage.id,
+        createdSolarPanel4ProductImage: createdSolarPanel4ProductImage.id,
+        createdCeLogo: createdCeLogo.id,
+        createdUlLogo: createdUlLogo.id,
+        createdMcsLogo: createdMcsLogo.id,
+        createdHeroContent1: createdHeroContent1.id,
+        createdHeroContent2: createdHeroContent2.id,
+        createdHeroContent3: createdHeroContent3.id,
+        createdHeroContent4: createdHeroContent4.id,
+        createdHeroContent5: createdHeroContent5.id,
+        createdHeroContent6: createdHeroContent6.id,
+      },
+    });
+  } catch (e) {
+    payload.logger.error({ err: e, message: "Error seeding data" });
+    return new Response("Error seeding data.", { status: 500 });
+  }
+}

--- a/apps/cms/src/app/next/seed/reset/route.ts
+++ b/apps/cms/src/app/next/seed/reset/route.ts
@@ -1,0 +1,95 @@
+import { CollectionSlug, createLocalReq, GlobalSlug, Payload, PayloadRequest } from "payload";
+import { getPayloadClient } from "@synoem/payload/client";
+import { headers } from "next/headers";
+
+export const maxDuration = 60;
+
+const collections: CollectionSlug[] = [
+  "faqs",
+  "pages",
+  "packaging-configs",
+  "warranties",
+  "solar-panels",
+  "solar-panel-categories",
+  "industries",
+  "images",
+];
+
+const globals: GlobalSlug[] = ["company-info", "contact-info", "social-links", "header"];
+
+async function resetDatabase(payload: Payload, req: PayloadRequest) {
+  try {
+    await Promise.all(
+      globals.map(async (global) => {
+        try {
+          await payload.updateGlobal({
+            slug: global,
+            data: {},
+            depth: 0,
+            context: {
+              skipRevalidation: true,
+            },
+          });
+          payload.logger.info(`Global ${global} reset`);
+        } catch (error) {
+          payload.logger.error(`Failed to reset global ${global}:`, error);
+          throw new Error(`Failed to reset global ${global}, skipping...`, { cause: error });
+        }
+      }),
+    );
+
+    payload.logger.info("Globals reset");
+
+    for (const collection of collections) {
+      await payload.db.deleteMany({ collection, req, where: {} });
+    }
+
+    payload.logger.info("Collections reset");
+
+    await Promise.all(
+      collections
+        .filter((collection) => Boolean(payload.collections[collection].config.versions))
+        .map(async (collection) => {
+          try {
+            await payload.db.deleteVersions({ collection, req, where: {} });
+            payload.logger.info(`Versions for ${collection} reset`);
+          } catch (error) {
+            payload.logger.error(`Failed to reset versions for ${collection}:`, error);
+            throw new Error(`Failed to reset versions for ${collection}, skipping...`, {
+              cause: error,
+            });
+          }
+        }),
+    );
+
+    payload.logger.info("Versions reset");
+  } catch (error) {
+    payload.logger.error("Resetting database failed:", error);
+    throw error;
+  }
+}
+
+export async function POST(): Promise<Response> {
+  const payload = await getPayloadClient();
+  const requestHeaders = await headers();
+
+  // Authenticate by passing request headers
+  const { user } = await payload.auth({ headers: requestHeaders });
+
+  if (!user) {
+    return new Response("Action forbidden.", { status: 403 });
+  }
+
+  try {
+    // Create a Payload request object to pass to the Local API for transactions
+    // At this point you should pass in a user, locale, and any other context you need for the Local API
+    const payloadReq = await createLocalReq({ user }, payload);
+
+    await resetDatabase(payload, payloadReq);
+
+    return Response.json({ success: true });
+  } catch (e) {
+    payload.logger.error({ err: e, message: "Error seeding data" });
+    return new Response("Error seeding data.", { status: 500 });
+  }
+}

--- a/apps/cms/src/app/next/seed/seed.ts
+++ b/apps/cms/src/app/next/seed/seed.ts
@@ -1,3 +1,5 @@
+// TODO: divide into multiple calls as Vercel free tier has only 60s execution time
+
 import type { CollectionSlug, Payload, PayloadRequest, File, GlobalSlug } from "payload";
 import { faqs } from "./data/faqs";
 import { getAboutUsData, getHomeData } from "./data/pages";

--- a/apps/cms/src/components/before-dashboard/index.tsx
+++ b/apps/cms/src/components/before-dashboard/index.tsx
@@ -1,14 +1,155 @@
-import { SeedButton } from "./seed-button";
+"use client";
+
+import { Button, toast } from "@payloadcms/ui";
 import { Banner } from "@payloadcms/ui/elements/Banner";
-import React from "react";
+import React, { useCallback, useState } from "react";
 
 export default function BeforeDashboard() {
+  const [currentStep, setCurrentStep] = useState<number>(0);
+  const [loadingStep, setLoadingStep] = useState<number | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const [images, setImages] = useState<string[]>([]);
+
+  const steps: {
+    label: string;
+    endpoint: string;
+    success: string;
+    getBody?: () => Promise<any> | any;
+    onSuccess?: (data: any) => void;
+  }[] = [
+    {
+      label: "Reset Database",
+      endpoint: "/next/seed/reset",
+      success: "Database reset successfully.",
+    },
+    {
+      label: "Seed Images",
+      endpoint: "/next/seed/images",
+      success: "Images seeded successfully.",
+      onSuccess: setImages,
+    },
+    {
+      label: "Seed Pages",
+      endpoint: "/next/seed/pages",
+      success: "Pages seeded successfully.",
+      getBody: () => ({ images }),
+    },
+    // Add more steps as needed
+  ];
+
+  // const handleSeed = useCallback(
+  //   (index: number) => {
+  //     setLoadingStep(index);
+  //     setError(null);
+
+  //     if (!process.env.NEXT_PUBLIC_S3_ENDPOINT || !process.env.NEXT_PUBLIC_S3_BUCKET_NAME) {
+  //       setError("S3_ENDPOINT and S3_BUCKET_NAME must be set");
+  //       setLoadingStep(null);
+  //       return;
+  //     }
+
+  //     const { endpoint, success, getBody, onSuccess } = steps[index] || {};
+
+  //     if (!endpoint) {
+  //       setError("Invalid endpoint");
+  //       setLoadingStep(null);
+  //       return;
+  //     }
+
+  //     try {
+  //       const result = toast.promise(
+  //         fetch(endpoint, {
+  //           method: "POST",
+  //           credentials: "include",
+  //           headers: { "Content-Type": "application/json" },
+  //           ...(getBody && { body: JSON.stringify(getBody()) }),
+  //         }).then((res) => res.json()),
+  //         { loading: "Seeding...", success: "Success!", error: "Error!" },
+  //       );
+
+  //       if (onSuccess) onSuccess(result.images);
+
+  //       setCurrentStep(index + 1);
+
+  //       return true;
+  //     } catch (err) {}
+
+  //     try {
+  //       toast.promise(
+  //         fetch(endpoint, {
+  //           method: "POST",
+  //           credentials: "include",
+  //           headers: { "Content-Type": "application/json" },
+  //           ...(getBody && { body: JSON.stringify(getBody()) }),
+  //         }).then(async (res) => {
+  //           if (res.ok) {
+  //             setCurrentStep(index + 1);
+  //             return true;
+  //           } else {
+  //             // Try to extract error message from response
+  //             let msg = "An error occurred while seeding.";
+  //             try {
+  //               const data = await res.json();
+  //               if (data?.error) msg = data.error;
+  //             } catch {}
+  //             throw new Error(msg);
+  //           }
+  //         }),
+  //         {
+  //           loading: `Running: ${steps[index]?.label}...`,
+  //           success: success,
+  //           error: (err: any) => {
+  //             setError(err.message || "An error occurred while seeding.");
+  //             return err.message || "An error occurred while seeding.";
+  //           },
+  //         },
+  //       );
+  //     } catch (err) {
+  //       setError(typeof err === "string" ? err : "An error occurred while seeding.");
+  //     } finally {
+  //       setLoadingStep(null);
+  //     }
+  //   },
+  //   [steps],
+  // );
+
   return (
-    <div className="flex justify-between p-4 items-center">
-      <Banner type="success">
+    <div className="flex flex-col justify-between p-4 items-center gap-4">
+      <Banner type="info">
         <h4>Welcome to your dashboard!</h4>
+        <span>
+          Use the following buttons to seed some predefined data. Each step must be completed in
+          order.
+        </span>
       </Banner>
-      <SeedButton />
+      {error && (
+        <Banner type="error" className="my-4">
+          {error}
+        </Banner>
+      )}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-4">
+        {steps.map((step, index) => (
+          <SeedButton
+            key={index}
+            label={loadingStep === index ? "Seeding..." : step.label}
+            onClick={() => console.log(index)}
+            disabled={currentStep !== index || loadingStep !== null}
+          />
+        ))}
+      </div>
     </div>
   );
 }
+
+const SeedButton = ({
+  label,
+  onClick,
+  disabled,
+}: { label: string; onClick: () => void; disabled: boolean }) => {
+  return (
+    <Button buttonStyle="primary" onClick={onClick} disabled={disabled}>
+      {label}
+    </Button>
+  );
+};

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -64,6 +64,3 @@ export default withNextIntl(withBundleAnalyzer(nextConfig));
 
 import { initOpenNextCloudflareForDev } from "@opennextjs/cloudflare";
 initOpenNextCloudflareForDev();
-
-// Just for debugging
-console.log("ENV DUMP", process.env);

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,7 +16,7 @@
     "@hookform/resolvers": "^5.0.1",
     "@marsidev/react-turnstile": "^1.1.0",
     "@next-safe-action/adapter-react-hook-form": "^2.0.0",
-    "@opennextjs/cloudflare": "^1.1.0",
+    "@opennextjs/cloudflare": "^1.2.1",
     "@payloadcms/live-preview-react": "catalog:",
     "@react-three/drei": "catalog:",
     "@react-three/fiber": "catalog:",
@@ -49,7 +49,7 @@
     "zod": "catalog:"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "4.20250603.0",
+    "@cloudflare/workers-types": "4.20250610.0",
     "@lingual/i18n-check": "^0.8.4",
     "@next/bundle-analyzer": "catalog:",
     "@synoem/typescript-config": "workspace:*",
@@ -59,6 +59,6 @@
     "@types/react-dom": "catalog:",
     "tailwindcss": "catalog:",
     "typescript": "catalog:",
-    "wrangler": "^4.18.0"
+    "wrangler": "^4.19.1"
   }
 }

--- a/packages/payload/src/payload.config.ts
+++ b/packages/payload/src/payload.config.ts
@@ -125,7 +125,7 @@ export default buildConfig({
     pool: {
       connectionString: process.env.DATABASE_URI || "",
     },
-    push: true,
+    push: process.env.CMS_APP_ENV === "development",
   }),
   collections: [
     Users,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -172,8 +172,8 @@ importers:
         specifier: ^2.0.0
         version: 2.0.0(@hookform/resolvers@5.0.1(react-hook-form@7.56.4(react@19.1.0)))(next-safe-action@8.0.0(next@15.3.3(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.77.4))(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(next@15.3.3(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.77.4))(react-dom@19.1.0(react@19.1.0))(react-hook-form@7.56.4(react@19.1.0))(react@19.1.0)
       '@opennextjs/cloudflare':
-        specifier: ^1.1.0
-        version: 1.1.0(wrangler@4.18.0(@cloudflare/workers-types@4.20250603.0))
+        specifier: ^1.2.1
+        version: 1.2.1(wrangler@4.19.1(@cloudflare/workers-types@4.20250610.0))
       '@payloadcms/live-preview-react':
         specifier: 'catalog:'
         version: 3.42.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -266,8 +266,8 @@ importers:
         version: 3.25.23
     devDependencies:
       '@cloudflare/workers-types':
-        specifier: 4.20250603.0
-        version: 4.20250603.0
+        specifier: 4.20250610.0
+        version: 4.20250610.0
       '@lingual/i18n-check':
         specifier: ^0.8.4
         version: 0.8.4
@@ -296,8 +296,8 @@ importers:
         specifier: 'catalog:'
         version: 5.8.3
       wrangler:
-        specifier: ^4.18.0
-        version: 4.18.0(@cloudflare/workers-types@4.20250603.0)
+        specifier: ^4.19.1
+        version: 4.19.1(@cloudflare/workers-types@4.20250610.0)
 
   packages/config:
     devDependencies:
@@ -309,7 +309,7 @@ importers:
     dependencies:
       '@payloadcms/db-postgres':
         specifier: 'catalog:'
-        version: 3.42.0(@cloudflare/workers-types@4.20250603.0)(@opentelemetry/api@1.9.0)(@types/react@19.1.5)(payload@3.42.0(graphql@16.11.0)(typescript@5.8.3))(react@19.1.0)
+        version: 3.42.0(@cloudflare/workers-types@4.20250610.0)(@opentelemetry/api@1.9.0)(@types/react@19.1.5)(payload@3.42.0(graphql@16.11.0)(typescript@5.8.3))(react@19.1.0)
       '@payloadcms/email-resend':
         specifier: 'catalog:'
         version: 3.42.0(payload@3.42.0(graphql@16.11.0)(typescript@5.8.3))
@@ -1049,8 +1049,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@cloudflare/workers-types@4.20250603.0':
-    resolution: {integrity: sha512-62g5wVdXiRRu9sfC9fmwgZfE9W0rWy2txlgRKn1Xx1NWHshSdh4RWMX6gO4EBKPqgwlHKaMuSPZ1qM0hHsq7bA==}
+  '@cloudflare/workers-types@4.20250610.0':
+    resolution: {integrity: sha512-HxnUoey3QxCEfy07pUm7J42jBi9YPHq/hA3fw6JmOqYLHdviHI28OA8lup+2RUaHwDzh6q1DSfrBvvDqde645A==}
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -2353,15 +2353,15 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@opennextjs/aws@3.6.4':
-    resolution: {integrity: sha512-/bn9N/6dVu9+sC7AptaGJylKUzyDDgqe3yKfvUxXOpy7whIq/+3Bw+q2/bilyQg6FcskbCWUt9nLvNf1hAVmfA==}
+  '@opennextjs/aws@3.6.5':
+    resolution: {integrity: sha512-wni+CWlRCyWfhNfekQBBPPkrDDnaGdZLN9hMybKI0wKOKTO+zhPOqR65Eh3V0pzWAi84Sureb5mdMuLwCxAAcw==}
     hasBin: true
 
-  '@opennextjs/cloudflare@1.1.0':
-    resolution: {integrity: sha512-8DOzpLiewivA1pwRNGVPDXbrF79bzJiHscY+M1tekwvKqEqM26CRYafhrA5IDCeyteNaL9AZD6X4DLuCn/eeYQ==}
+  '@opennextjs/cloudflare@1.2.1':
+    resolution: {integrity: sha512-cOco+nHwlo/PLB1bThF8IIvaS8PgAT9MEI5ZttFO/qt6spgvr2lUaPkpjgSIQmI3sBIEG2cLUykvQ2nbbZEcVw==}
     hasBin: true
     peerDependencies:
-      wrangler: ^4.14.0
+      wrangler: ^4.19.1
 
   '@opentelemetry/api@1.9.0':
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
@@ -4249,6 +4249,10 @@ packages:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
 
+  cookie@1.0.2:
+    resolution: {integrity: sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==}
+    engines: {node: '>=18'}
+
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
 
@@ -5664,8 +5668,8 @@ packages:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
     engines: {node: '>=18'}
 
-  miniflare@4.20250525.0:
-    resolution: {integrity: sha512-F5XRDn9WqxUaHphUT8qwy5WXC/3UwbBRJTdjjP5uwHX82vypxIlHNyHziZnplPLhQa1kbSdIY7wfuP1XJyyYZw==}
+  miniflare@4.20250525.1:
+    resolution: {integrity: sha512-4PJlT5WA+hfclFU5Q7xnpG1G1VGYTXaf/3iu6iKQ8IsbSi9QvPTA2bSZ5goCFxmJXDjV4cxttVxB0Wl1CLuQ0w==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
@@ -7230,8 +7234,8 @@ packages:
     engines: {node: '>=16'}
     hasBin: true
 
-  wrangler@4.18.0:
-    resolution: {integrity: sha512-/ng0KI9io97SNsBU1rheADBLLTE5Djybgsi4gXuvH1RBKJGpyj1xWvZ2fuWu8vAonit3EiZkwtERTm6kESHP3A==}
+  wrangler@4.19.1:
+    resolution: {integrity: sha512-b+ed2SJKauHgndl4Im1wHE+FeSSlrdlEZNuvpc8q/94k4EmRxRkXnwBAsVWuicBxG3HStFLQPGGlvL8wGKTtHw==}
     engines: {node: '>=18.0.0'}
     hasBin: true
     peerDependencies:
@@ -8534,7 +8538,7 @@ snapshots:
   '@cloudflare/workerd-windows-64@1.20250525.0':
     optional: true
 
-  '@cloudflare/workers-types@4.20250603.0': {}
+  '@cloudflare/workers-types@4.20250610.0': {}
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
@@ -9594,7 +9598,7 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
 
-  '@opennextjs/aws@3.6.4':
+  '@opennextjs/aws@3.6.5':
     dependencies:
       '@ast-grep/napi': 0.35.0
       '@aws-sdk/client-cloudfront': 3.398.0
@@ -9607,6 +9611,7 @@ snapshots:
       '@tsconfig/node18': 1.0.3
       aws4fetch: 1.0.20
       chalk: 5.4.1
+      cookie: 1.0.2
       esbuild: 0.25.4
       express: 5.0.1
       path-to-regexp: 6.3.0
@@ -9616,14 +9621,14 @@ snapshots:
       - aws-crt
       - supports-color
 
-  '@opennextjs/cloudflare@1.1.0(wrangler@4.18.0(@cloudflare/workers-types@4.20250603.0))':
+  '@opennextjs/cloudflare@1.2.1(wrangler@4.19.1(@cloudflare/workers-types@4.20250610.0))':
     dependencies:
       '@dotenvx/dotenvx': 1.31.0
-      '@opennextjs/aws': 3.6.4
+      '@opennextjs/aws': 3.6.5
       enquirer: 2.4.1
       glob: 11.0.2
       ts-tqdm: 0.8.6
-      wrangler: 4.18.0(@cloudflare/workers-types@4.20250603.0)
+      wrangler: 4.19.1(@cloudflare/workers-types@4.20250610.0)
     transitivePeerDependencies:
       - aws-crt
       - supports-color
@@ -9631,13 +9636,13 @@ snapshots:
   '@opentelemetry/api@1.9.0':
     optional: true
 
-  '@payloadcms/db-postgres@3.42.0(@cloudflare/workers-types@4.20250603.0)(@opentelemetry/api@1.9.0)(@types/react@19.1.5)(payload@3.42.0(graphql@16.11.0)(typescript@5.8.3))(react@19.1.0)':
+  '@payloadcms/db-postgres@3.42.0(@cloudflare/workers-types@4.20250610.0)(@opentelemetry/api@1.9.0)(@types/react@19.1.5)(payload@3.42.0(graphql@16.11.0)(typescript@5.8.3))(react@19.1.0)':
     dependencies:
-      '@payloadcms/drizzle': 3.42.0(@cloudflare/workers-types@4.20250603.0)(@opentelemetry/api@1.9.0)(@types/pg@8.10.2)(@types/react@19.1.5)(payload@3.42.0(graphql@16.11.0)(typescript@5.8.3))(pg@8.11.3)(react@19.1.0)
+      '@payloadcms/drizzle': 3.42.0(@cloudflare/workers-types@4.20250610.0)(@opentelemetry/api@1.9.0)(@types/pg@8.10.2)(@types/react@19.1.5)(payload@3.42.0(graphql@16.11.0)(typescript@5.8.3))(pg@8.11.3)(react@19.1.0)
       '@types/pg': 8.10.2
       console-table-printer: 2.12.1
       drizzle-kit: 0.28.0
-      drizzle-orm: 0.36.1(@cloudflare/workers-types@4.20250603.0)(@opentelemetry/api@1.9.0)(@types/pg@8.10.2)(@types/react@19.1.5)(pg@8.11.3)(react@19.1.0)
+      drizzle-orm: 0.36.1(@cloudflare/workers-types@4.20250610.0)(@opentelemetry/api@1.9.0)(@types/pg@8.10.2)(@types/react@19.1.5)(pg@8.11.3)(react@19.1.0)
       payload: 3.42.0(graphql@16.11.0)(typescript@5.8.3)
       pg: 8.11.3
       prompts: 2.4.2
@@ -9674,11 +9679,11 @@ snapshots:
       - sqlite3
       - supports-color
 
-  '@payloadcms/drizzle@3.42.0(@cloudflare/workers-types@4.20250603.0)(@opentelemetry/api@1.9.0)(@types/pg@8.10.2)(@types/react@19.1.5)(payload@3.42.0(graphql@16.11.0)(typescript@5.8.3))(pg@8.11.3)(react@19.1.0)':
+  '@payloadcms/drizzle@3.42.0(@cloudflare/workers-types@4.20250610.0)(@opentelemetry/api@1.9.0)(@types/pg@8.10.2)(@types/react@19.1.5)(payload@3.42.0(graphql@16.11.0)(typescript@5.8.3))(pg@8.11.3)(react@19.1.0)':
     dependencies:
       console-table-printer: 2.12.1
       dequal: 2.0.3
-      drizzle-orm: 0.36.1(@cloudflare/workers-types@4.20250603.0)(@opentelemetry/api@1.9.0)(@types/pg@8.10.2)(@types/react@19.1.5)(pg@8.11.3)(react@19.1.0)
+      drizzle-orm: 0.36.1(@cloudflare/workers-types@4.20250610.0)(@opentelemetry/api@1.9.0)(@types/pg@8.10.2)(@types/react@19.1.5)(pg@8.11.3)(react@19.1.0)
       payload: 3.42.0(graphql@16.11.0)(typescript@5.8.3)
       prompts: 2.4.2
       to-snake-case: 1.0.0
@@ -11846,6 +11851,8 @@ snapshots:
 
   cookie@0.7.2: {}
 
+  cookie@1.0.2: {}
+
   core-util-is@1.0.3: {}
 
   cors@2.8.5:
@@ -12072,9 +12079,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  drizzle-orm@0.36.1(@cloudflare/workers-types@4.20250603.0)(@opentelemetry/api@1.9.0)(@types/pg@8.10.2)(@types/react@19.1.5)(pg@8.11.3)(react@19.1.0):
+  drizzle-orm@0.36.1(@cloudflare/workers-types@4.20250610.0)(@opentelemetry/api@1.9.0)(@types/pg@8.10.2)(@types/react@19.1.5)(pg@8.11.3)(react@19.1.0):
     optionalDependencies:
-      '@cloudflare/workers-types': 4.20250603.0
+      '@cloudflare/workers-types': 4.20250610.0
       '@opentelemetry/api': 1.9.0
       '@types/pg': 8.10.2
       '@types/react': 19.1.5
@@ -13346,7 +13353,7 @@ snapshots:
 
   mimic-function@5.0.1: {}
 
-  miniflare@4.20250525.0:
+  miniflare@4.20250525.1:
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       acorn: 8.14.0
@@ -15104,18 +15111,18 @@ snapshots:
       '@cloudflare/workerd-linux-arm64': 1.20250525.0
       '@cloudflare/workerd-windows-64': 1.20250525.0
 
-  wrangler@4.18.0(@cloudflare/workers-types@4.20250603.0):
+  wrangler@4.19.1(@cloudflare/workers-types@4.20250610.0):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.4.0
       '@cloudflare/unenv-preset': 2.3.2(unenv@2.0.0-rc.17)(workerd@1.20250525.0)
       blake3-wasm: 2.1.5
       esbuild: 0.25.4
-      miniflare: 4.20250525.0
+      miniflare: 4.20250525.1
       path-to-regexp: 6.3.0
       unenv: 2.0.0-rc.17
       workerd: 1.20250525.0
     optionalDependencies:
-      '@cloudflare/workers-types': 4.20250603.0
+      '@cloudflare/workers-types': 4.20250610.0
       fsevents: 2.3.3
     transitivePeerDependencies:
       - bufferutil


### PR DESCRIPTION
Need to divide the seed scripts into several steps.

But first we need to deploy the frontend, otherwise we cannot add data manually due to the revalidation hooks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced multi-step seeding functionality in the CMS dashboard, allowing users to seed globals, images, and reset the database with improved UI feedback.
  - Added new API endpoints for seeding global data, images, and resetting the CMS database, each with authentication and error handling.

- **Bug Fixes**
  - Removed unnecessary environment variable logging from the web app configuration.

- **Chores**
  - Updated dependencies for improved stability and compatibility in the web app.
  - Adjusted database configuration to enable push functionality only in development environments.

- **Refactor**
  - Enhanced the CMS dashboard seeding UI for better usability and clearer progress tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->